### PR TITLE
Added the option to have a custom url (for a local LanguageTool server),

### DIFF
--- a/languagetool.go
+++ b/languagetool.go
@@ -8,13 +8,13 @@ import (
 	"net/url"
 )
 
-func Check(text, lang string) (Result, error) {
-	apiUrl := URL
+// CheckWithURL runs an api call for a custom languagetool server
+func CheckWithURL(text, lang, apiURL string) (Result, error) {
 	data := url.Values{}
 	data.Set("text", text)
 	data.Set("language", lang)
 	data.Set("enabledOnly", "false")
-	req, err := http.NewRequest("POST", apiUrl, bytes.NewBufferString(data.Encode()))
+	req, err := http.NewRequest("POST", apiURL, bytes.NewBufferString(data.Encode()))
 	if err != nil {
 		return Result{}, err
 	}
@@ -41,4 +41,9 @@ func Check(text, lang string) (Result, error) {
 	// TODO handle other status codes
 
 	return Result{}, nil
+}
+
+// Check runs an api call to the public LanguageTool API, to check the given text with the given lang
+func Check(text, lang string) (Result, error) {
+	return CheckWithURL(text, lang, URL)
 }

--- a/types.go
+++ b/types.go
@@ -4,66 +4,58 @@ const (
 	URL string = `https://languagetool.org/api/v2/check`
 )
 
-type Soft struct {
+type Warnings struct {
+	IncompleteResults bool `json:"incompleteResults"`
+}
+
+type Software struct {
 	Name       string `json:"name"`
 	Version    string `json:"version"`
 	BuildDate  string `json:"buildDate"`
-	ApiVersion int    `json:"apiVersion"`
+	APIVersion int    `json:"apiVersion"`
 	Status     string `json:"status"`
 }
 
-type Lang struct {
-	Name string `json:"name`
+type Language struct {
+	Name string `json:"name"`
 	Code string `json:"code"`
+}
+
+type Result struct {
+	Software Software `json:"software"`
+	Warnings Warnings `json:"warnings"`
+	Language Language `json:"language"`
+	Matches  []Match  `json:"matches"`
+}
+
+type Match struct {
+	Message      string        `json:"message"`
+	ShortMessage string        `json:"shortMessage"`
+	Replacements []Replacement `json:"replacements"`
+	Offset       int           `json:"offset"`
+	Length       int           `json:"length"`
+	Context      Context       `json:"context"`
+	Rule         Rule          `json:"rule"`
 }
 
 type Replacement struct {
 	Value string `json:"value"`
 }
 
-type ContextVal struct {
+type Context struct {
 	Text   string `json:"text"`
 	Offset int    `json:"offset"`
 	Length int    `json:"length"`
 }
 
-type RuleUrls struct {
-	Value string `json:"value"`
+type Rule struct {
+	ID          string   `json:"id"`
+	Description string   `json:"description"`
+	IssueType   string   `json:"issueType"`
+	Category    Category `json:"category"`
 }
 
-type RuleCategory struct {
-	Id   string `json:"id"`
+type Category struct {
+	ID   string `json:"id"`
 	Name string `json:"name"`
-}
-
-type RuleVal struct {
-	Id          string       `json:"id"`
-	SubId       string       `json:"subId"`
-	Description string       `json:"description"`
-	Urls        RuleUrls     `json:"urls"`
-	IssueType   string       `json:"issueType"`
-	Category    RuleCategory `json:"category"`
-}
-
-type Match struct {
-	Message      string        `json:"message"`
-	ShortMessage string        `json:"shortMessage"`
-	Offset       int           `json:"offset"`
-	Length       int           `json:"length"`
-	Replacements []Replacement `json:"replacements"`
-	Context      ContextVal    `json:"context"`
-	Rule         RuleVal       `json:"rule"`
-}
-
-type Result struct {
-	Software Soft    `json:"software"`
-	Language Lang    `json:"language"`
-	Matches  []Match `json:"matches"`
-}
-
-// supported languages
-type Languages struct {
-	Name     string `json:"name"`
-	Code     string `json:"code"`
-	LongCode string `json:"longCode"`
 }


### PR DESCRIPTION
I wanted to use this package but I have a local LanguageTool server.
Added the method `CheckWithURL(text, lang, apiURL string)` and copied the code over from `Check(text, lang string)`. Rerouted the Check function to avoid duplicate code.

No breaking changes, just additional functionality.